### PR TITLE
fix: Fixed pricing for home page's popular services with actual price

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -199,31 +199,33 @@ const popularServices = [
   {
     title: "DevOps Services",
     description: "Comprehensive DevOps solutions to optimize your development pipeline.",
-    price: "300",
+    price: "2500",
     features: [
-      "Infrastructure as Code",
+      "Infrastructure as Code (IaC)",
       "CI/CD Pipeline Setup",
-      "24/7 Monitoring"
+      "Cloud Migration Services",
+      "24/7 Monitoring Setup"
     ]
   },
   {
     title: "Career Guidance",
     description: "Personalized career counseling sessions with industry experts.",
-    price: "500",
+    price: "1000",
     features: [
       "Career Path Planning",
       "Interview Preparation",
-      "Skill Gap Analysis"
-    ]
+      "Skill Gap Analysis",
+      "Industry Insights"    ]
   },
   {
-    title: "LinkedIn Optimization",
+    title: "LinkedIn Profile Optimization",
     description: "Enhance your professional presence with an optimized profile.",
-    price: "250",
+    price: "1500",
     features: [
-      "Profile Enhancement",
-      "Custom Banner Design",
-      "Content Strategy"
+      "Keyword Optimization",
+      "Content Enhancement",
+      "Profile Structure",
+      "Network Growth Strategy"
     ]
   }
 ];


### PR DESCRIPTION
 Fixed pricing for home page's popular services with actual pricing in services page and also updated the features to be same as services page in home page.

I am not sure the popular services are different from services provided due to the the pricing and features are little different.

I assume it is a misconfiguration.

The reason for the fix is beacasue It might jeopardize customers trust.

So, I modified  the home page popular services to match services in service page.

Please find the screenshot/attchmements  for an after fix review.
![home](https://github.com/user-attachments/assets/292f91bb-a3a4-43e1-b708-1bd7400375b4)
![services-1](https://github.com/user-attachments/assets/55354920-f9e6-4ae1-a49d-f9307da63af6)
![services-2](https://github.com/user-attachments/assets/4c3a17cf-e381-479a-985e-da0f843c3ef2)


Issue reference:  #2 